### PR TITLE
Fix main button colors

### DIFF
--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -75,6 +75,8 @@ export const useBlockchain = defineStore('blockchain', {
         // } else {
         //   document.body.style.setProperty('--p', '237.65 100% 70%');
         // }
+        document.body.style.setProperty('--p', '154 85% 35%');
+        document.body.style.setProperty('--pc', '0 0% 100%');
         currNavItem = [
           {
             title: this.current?.prettyName || this.chainName || '',


### PR DESCRIPTION
Fix for using Allora branding colors on the explorer's buttons.

**Before:**
<img width="641" alt="Screenshot 2024-02-29 at 10 49 41" src="https://github.com/allora-network/explorer/assets/8314201/40ca114f-a199-4be2-96c5-90b42e902343">

**After:**
<img width="750" alt="Screenshot 2024-02-29 at 10 58 37" src="https://github.com/allora-network/explorer/assets/8314201/099ec31d-6360-43f6-9818-2b1500554412">
