### PR TITLE
Fix wallet connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 yarn-error.log
 dist
 .idea
+.DS_Store

--- a/chains/allora.json
+++ b/chains/allora.json
@@ -7,10 +7,16 @@
             "address": "https://allora-api.edgenet.allora.network:8443"
         }
     ],
+    "rpc": [
+        {
+            "provider": "upshot",
+            "address": "https://allora-rpc.edgenet.allora.network:8443"
+        }
+    ],
     "sdk_version": "0.45.1",
     "coin_type": "118",
     "min_tx_fee": "800",
-    "addr_prefix": "allora",
+    "addr_prefix": "allo",
     "assets": [
         {
             "base": "uallo",

--- a/index.html
+++ b/index.html
@@ -35,10 +35,10 @@
       gtag('js', new Date());
 
       gtag('config', 'G-SSBKVF3GMX');
-    </script>
+    </script>-->
     <script
       type="module"
       src="https://cdn.jsdelivr.net/npm/ping-widget@latest/dist/ping-widget.min.js"
-    ></script> -->
+    ></script>
   </body>
 </html>

--- a/src/layouts/components/DefaultLayout.vue
+++ b/src/layouts/components/DefaultLayout.vue
@@ -273,17 +273,7 @@ function selected(route: any, nav: NavLink) {
         </a>
 
         <div class="px-4 text-sm pt-2 text-gray-400 pb-2 uppercase">Tools</div>
-        <RouterLink
-          to="/wallet/suggest"
-          class="py-2 px-4 flex items-center cursor-pointer rounded-lg hover:bg-gray-100 dark:hover:bg-[#373f59]"
-        >
-          <Icon icon="mdi:frequently-asked-questions" class="text-xl mr-2" />
-          <div
-            class="text-base capitalize flex-1 text-gray-600 dark:text-gray-200"
-          >
-            Wallet Helper
-          </div>
-        </RouterLink>
+        
 
         <div class="px-4 text-sm pt-2 text-gray-400 pb-2 uppercase">
           {{ $t('module.links') }}
@@ -326,6 +316,18 @@ function selected(route: any, nav: NavLink) {
           </div>
         </a>
       </div> -->
+
+      <RouterLink
+        to="/wallet/suggest"
+        class="py-2 px-4 flex items-center cursor-pointer rounded-lg hover:bg-gray-100 dark:hover:bg-[#373f59]"
+      >
+        <Icon icon="mdi:frequently-asked-questions" class="text-xl mr-2" />
+        <div
+          class="text-base capitalize flex-1 text-gray-600 dark:text-gray-200"
+        >
+          Wallet Helper
+        </div>
+      </RouterLink>
     </div>
     <div class="xl:!ml-64 px-3 pt-4">
       <!-- header -->

--- a/src/modules/wallet/keplr.vue
+++ b/src/modules/wallet/keplr.vue
@@ -4,100 +4,121 @@ import { useDashboard, type ChainConfig, useBlockchain } from '@/stores';
 import { CosmosRestClient } from '@/libs/client';
 import { onMounted } from 'vue';
 
-const error = ref("")
-const conf = ref("")
-const dashboard = useDashboard()
-const selected = ref({} as ChainConfig)
+const error = ref('');
+const conf = ref('');
+const dashboard = useDashboard();
+const selected = ref({} as ChainConfig);
 
 onMounted(() => {
-    const chainStore = useBlockchain()
-    selected.value = chainStore.current || Object.values(dashboard.chains)[0]
-    initParamsForKeplr()
-})
+  const chainStore = useBlockchain();
+  selected.value = chainStore.current || Object.values(dashboard.chains)[0];
+  initParamsForKeplr();
+});
 async function initParamsForKeplr() {
-    const chain = selected.value
-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
-    const b = await client.getBaseBlockLatest()   
-    const chainid = b.block.header.chain_id
+  const chain = selected.value;
+  if (!chain.endpoints?.rest?.at(0)) throw new Error('Endpoint does not set');
+  const client = CosmosRestClient.newDefault(
+    chain.endpoints.rest?.at(0)?.address || ''
+  );
+  const b = await client.getBaseBlockLatest();
+  const chainid = b.block.header.chain_id;
 
-    const gasPriceStep = chain.keplrPriceStep || {
-        low: 0.01,
-        average: 0.025,
-        high: 0.03,
-    }
-    const coinDecimals = chain.assets[0].denom_units.find(x => x.denom === chain.assets[0].symbol.toLowerCase())?.exponent || 6
-    conf.value = JSON.stringify({
-        chainId: chainid,
-        chainName: chain.chainName,
-        rpc: chain.endpoints?.rpc?.at(0)?.address,
-        rest: chain.endpoints?.rest?.at(0)?.address,
-        bip44: {
-            coinType: Number(chain.coinType),
-        },
+  const gasPriceStep = chain.keplrPriceStep || {
+    low: 0.01,
+    average: 0.025,
+    high: 0.03,
+  };
+  const coinDecimals =
+    chain.assets[0].denom_units.find(
+      (x) => x.denom === chain.assets[0].symbol.toLowerCase()
+    )?.exponent || 6;
+  conf.value = JSON.stringify(
+    {
+      chainId: chainid,
+      chainName: chain.chainName,
+      rpc: chain.endpoints?.rpc?.at(0)?.address,
+      rest: chain.endpoints?.rest?.at(0)?.address,
+      bip44: {
         coinType: Number(chain.coinType),
-        bech32Config: {
-            bech32PrefixAccAddr: chain.bech32Prefix,
-            bech32PrefixAccPub: `${chain.bech32Prefix}pub`,
-            bech32PrefixValAddr: `${chain.bech32Prefix}valoper`,
-            bech32PrefixValPub: `${chain.bech32Prefix}valoperpub`,
-            bech32PrefixConsAddr: `${chain.bech32Prefix}valcons`,
-            bech32PrefixConsPub: `${chain.bech32Prefix}valconspub`,
+      },
+      coinType: Number(chain.coinType),
+      bech32Config: {
+        bech32PrefixAccAddr: chain.bech32Prefix,
+        bech32PrefixAccPub: `${chain.bech32Prefix}pub`,
+        bech32PrefixValAddr: `${chain.bech32Prefix}valoper`,
+        bech32PrefixValPub: `${chain.bech32Prefix}valoperpub`,
+        bech32PrefixConsAddr: `${chain.bech32Prefix}valcons`,
+        bech32PrefixConsPub: `${chain.bech32Prefix}valconspub`,
+      },
+      currencies: [
+        {
+          coinDenom: chain.assets[0].symbol,
+          coinMinimalDenom: chain.assets[0].base,
+          coinDecimals,
+          coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
         },
-        currencies: [
-            {
-                coinDenom: chain.assets[0].symbol,
-                coinMinimalDenom: chain.assets[0].base,
-                coinDecimals,
-                coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
-            },
-        ],
-        feeCurrencies: [
-            {
-                coinDenom: chain.assets[0].symbol,
-                coinMinimalDenom: chain.assets[0].base,
-                coinDecimals,
-                coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
-                gasPriceStep,
-            },
-        ],
-        gasPriceStep,
-        stakeCurrency: {
-            coinDenom: chain.assets[0].symbol,
-            coinMinimalDenom: chain.assets[0].base,
-            coinDecimals,
-            coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+      ],
+      feeCurrencies: [
+        {
+          coinDenom: chain.assets[0].symbol,
+          coinMinimalDenom: chain.assets[0].base,
+          coinDecimals,
+          coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+          gasPriceStep,
         },
-        features: chain.keplrFeatures || [],
-    }, null, '\t')
+      ],
+      gasPriceStep,
+      stakeCurrency: {
+        coinDenom: chain.assets[0].symbol,
+        coinMinimalDenom: chain.assets[0].base,
+        coinDecimals,
+        coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+      },
+      features: chain.keplrFeatures || [],
+    },
+    null,
+    '\t'
+  );
 }
 
 function suggest() {
+  // @ts-ignore
+  if (window.keplr) {
     // @ts-ignore
-    if (window.keplr) {
-        // @ts-ignore
-        window.keplr.experimentalSuggestChain(JSON.parse(conf.value)).catch(e => {
-            error.value = e
-        })
-    }
+    window.keplr.experimentalSuggestChain(JSON.parse(conf.value)).catch((e) => {
+      console.log(e);
+      error.value = e;
+    });
+  }
 }
 </script>
 
 <template>
-    <div class="bg-base-100 p-4 rounded text-center">
-        <div class="flex">
-            <select v-model="selected" class="select select-bordered mx-5" @change="initParamsForKeplr">
-                <option v-for="c in dashboard.chains" :value="c">
-                    {{ c.chainName }}
-                </option>
-            </select>
-            <button class="btn !bg-yes !border-yes text-white px-10" @click="suggest">Add {{ selected.chainName }} TO Keplr Wallet</button>
-        </div>
-        <div class="text-main mt-5">
-            <textarea v-model="conf" class="textarea textarea-bordered w-full" rows="15"></textarea>
-        </div>
-        <div class="mt-4 mb-4">
-            If the chain is not offically support on Keplr, you can submit these parameters to enable Keplr.
-        </div>
+  <div class="bg-base-100 p-4 rounded text-center">
+    <div class="flex">
+      <select
+        v-model="selected"
+        class="select select-bordered mx-5"
+        @change="initParamsForKeplr"
+      >
+        <option v-for="c in dashboard.chains" :value="c">
+          {{ c.chainName }}
+        </option>
+      </select>
+      <button class="btn !bg-yes !border-yes text-white px-10" @click="suggest">
+        Add {{ selected.chainName }} TO Keplr Wallet
+      </button>
     </div>
+    <div class="text-main mt-5">
+      <textarea
+        v-model="conf"
+        class="textarea textarea-bordered w-full"
+        rows="15"
+      ></textarea>
+    </div>
+    <div class="mt-4 mb-4">
+      If the chain is not offically support on Keplr, you can submit these
+      parameters to enable Keplr.
+    </div>
+  </div>
 </template>

--- a/src/modules/wallet/suggest.vue
+++ b/src/modules/wallet/suggest.vue
@@ -1,172 +1,253 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { suggestChain } from '@leapwallet/cosmos-snap-provider';
-import { useDashboard, type ChainConfig, useBlockchain, NetworkType } from '@/stores';
+import {
+  useDashboard,
+  type ChainConfig,
+  useBlockchain,
+  NetworkType,
+} from '@/stores';
 import { CosmosRestClient } from '@/libs/client';
 import { onMounted } from 'vue';
 
-const error = ref("")
-const conf = ref("")
-const dashboard = useDashboard()
-const selected = ref({} as ChainConfig)
-const wallet = ref("keplr")
-const network = ref(NetworkType.Mainnet)
-const mainnet = ref([] as ChainConfig[])
-const testnet = ref([] as ChainConfig[])
+const error = ref('');
+const conf = ref('');
+const dashboard = useDashboard();
+const selected = ref({} as ChainConfig);
+const wallet = ref('keplr');
+const network = ref(NetworkType.Testnet);
+const mainnet = ref([] as ChainConfig[]);
+const testnet = ref([] as ChainConfig[]);
 const chains = computed(() => {
-    return network.value === NetworkType.Mainnet? mainnet.value : testnet.value
-})
+  return network.value === NetworkType.Mainnet ? mainnet.value : testnet.value;
+});
 
 onMounted(() => {
-    const chainStore = useBlockchain()
-    selected.value = chainStore.current || Object.values(dashboard.chains)[0]
-    initParamsForKeplr()
+  const chainStore = useBlockchain();
+  selected.value = chainStore.current || Object.values(chains)[0];
+  initParamsForCosmosWallets();
 
-    dashboard.loadLocalConfig(NetworkType.Mainnet).then((res) => {
-        mainnet.value = Object.values<ChainConfig>(res)
-    })
-    dashboard.loadLocalConfig(NetworkType.Testnet).then((res) => {
-        testnet.value = Object.values<ChainConfig>(res)
-    })
-})
+  dashboard.loadLocalConfig(NetworkType.Mainnet).then((res) => {
+    mainnet.value = Object.values<ChainConfig>(res);
+  });
+  dashboard.loadLocalConfig(NetworkType.Testnet).then((res) => {
+    testnet.value = Object.values<ChainConfig>(res);
+  });
+});
 
 function onchange() {
-    wallet.value === "keplr" ? initParamsForKeplr() : initSnap()
+  wallet.value === 'keplr' || wallet.value === 'leap'
+    ? initParamsForCosmosWallets()
+    : initSnap();
 }
 
-async function initParamsForKeplr() {
-    const chain = selected.value
-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
-    const b = await client.getBaseBlockLatest()   
-    const chainid = b.block.header.chain_id
+async function initParamsForCosmosWallets() {
+  const chain = selected.value;
+  if (!chain.endpoints?.rest?.at(0)) throw new Error('Endpoint does not set');
+  const client = CosmosRestClient.newDefault(
+    chain.endpoints.rest?.at(0)?.address || ''
+  );
+  const b = await client.getBaseBlockLatest();
+  const chainid = b.block.header.chain_id;
 
-    const gasPriceStep = chain.keplrPriceStep || {
-        low: 0.01,
-        average: 0.025,
-        high: 0.03,
-    }
-    const coinDecimals = chain.assets[0].denom_units.find(x => x.denom === chain.assets[0].symbol.toLowerCase())?.exponent || 6
-    conf.value = JSON.stringify({
-        chainId: chainid,
-        chainName: chain.chainName,
-        rpc: chain.endpoints?.rpc?.at(0)?.address,
-        rest: chain.endpoints?.rest?.at(0)?.address,
-        bip44: {
-            coinType: Number(chain.coinType),
-        },
+  const gasPriceStep = chain.keplrPriceStep || {
+    low: 0.01,
+    average: 0.025,
+    high: 0.03,
+  };
+  const coinDecimals =
+    chain.assets[0].denom_units.find(
+      (x) => x.denom === chain.assets[0].symbol.toLowerCase()
+    )?.exponent || 6;
+
+  conf.value = JSON.stringify(
+    {
+      chainId: chainid,
+      chainName: chain.chainName,
+      rpc: chain.endpoints?.rpc?.at(0)?.address,
+      rest: chain.endpoints?.rest?.at(0)?.address,
+      bip44: {
         coinType: Number(chain.coinType),
-        bech32Config: {
-            bech32PrefixAccAddr: chain.bech32Prefix,
-            bech32PrefixAccPub: `${chain.bech32Prefix}pub`,
-            bech32PrefixValAddr: `${chain.bech32Prefix}valoper`,
-            bech32PrefixValPub: `${chain.bech32Prefix}valoperpub`,
-            bech32PrefixConsAddr: `${chain.bech32Prefix}valcons`,
-            bech32PrefixConsPub: `${chain.bech32Prefix}valconspub`,
+      },
+      coinType: Number(chain.coinType),
+      bech32Config: {
+        bech32PrefixAccAddr: chain.bech32Prefix,
+        bech32PrefixAccPub: `${chain.bech32Prefix}pub`,
+        bech32PrefixValAddr: `${chain.bech32Prefix}valoper`,
+        bech32PrefixValPub: `${chain.bech32Prefix}valoperpub`,
+        bech32PrefixConsAddr: `${chain.bech32Prefix}valcons`,
+        bech32PrefixConsPub: `${chain.bech32Prefix}valconspub`,
+      },
+      currencies: [
+        {
+          coinDenom: chain.assets[0].symbol,
+          coinMinimalDenom: chain.assets[0].base,
+          coinDecimals,
+          coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
         },
-        currencies: [
-            {
-                coinDenom: chain.assets[0].symbol,
-                coinMinimalDenom: chain.assets[0].base,
-                coinDecimals,
-                coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
-            },
-        ],
-        feeCurrencies: [
-            {
-                coinDenom: chain.assets[0].symbol,
-                coinMinimalDenom: chain.assets[0].base,
-                coinDecimals,
-                coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
-                gasPriceStep,
-            },
-        ],
-        gasPriceStep,
-        stakeCurrency: {
-            coinDenom: chain.assets[0].symbol,
-            coinMinimalDenom: chain.assets[0].base,
-            coinDecimals,
-            coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+      ],
+      feeCurrencies: [
+        {
+          coinDenom: chain.assets[0].symbol,
+          coinMinimalDenom: chain.assets[0].base,
+          coinDecimals,
+          coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+          gasPriceStep,
         },
-        features: chain.keplrFeatures || [],
-    }, null, '\t')
+      ],
+      gasPriceStep,
+      stakeCurrency: {
+        coinDenom: chain.assets[0].symbol,
+        coinMinimalDenom: chain.assets[0].base,
+        coinDecimals,
+        coinGeckoId: chain.assets[0].coingecko_id || 'unknown',
+      },
+      features: chain.keplrFeatures || [],
+    },
+    null,
+    '\t'
+  );
 }
 
 async function initSnap() {
-    const chain = selected.value
-    const [token] = chain.assets
+  const chain = selected.value;
+  const [token] = chain.assets;
 
-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
-    const b = await client.getBaseBlockLatest()   
-    const chainId = b.block.header.chain_id
+  if (!chain.endpoints?.rest?.at(0)) throw new Error('Endpoint does not set');
+  const client = CosmosRestClient.newDefault(
+    chain.endpoints.rest?.at(0)?.address || ''
+  );
+  const b = await client.getBaseBlockLatest();
+  const chainId = b.block.header.chain_id;
 
-    conf.value = JSON.stringify({
-        chainId,
-        chainName: chain.chainName,
-        bech32Config: {
-            bech32PrefixAccAddr: chain.bech32Prefix,
+  conf.value = JSON.stringify(
+    {
+      chainId,
+      chainName: chain.chainName,
+      bech32Config: {
+        bech32PrefixAccAddr: chain.bech32Prefix,
+      },
+      bip44: {
+        coinType: Number(chain.coinType),
+      },
+      feeCurrencies: [
+        {
+          coinDenom: token.display,
+          coinMinimalDenom: token.base,
+          coinDecimals:
+            token.denom_units.find((x) => x.denom === token.display)
+              ?.exponent || 6,
+          coinGeckoId: token.coingecko_id,
+          gasPriceStep: {
+            low: 0.0625,
+            average: 0.5,
+            high: 62.5,
+          },
         },
-        bip44: {
-            coinType: Number(chain.coinType),
-        },
-        feeCurrencies: [
-            {
-            coinDenom: token.display,
-            coinMinimalDenom: token.base,
-            coinDecimals: token.denom_units.find(x => x.denom === token.display)?.exponent || 6,
-            coinGeckoId: token.coingecko_id,
-            gasPriceStep: {
-                low: 0.0625,
-                average: 0.5,
-                high: 62.5,
-            },
-            },
-        ],
-    }, null, '\t')
+      ],
+    },
+    null,
+    '\t'
+  );
 }
 
 function suggest() {
-    if(wallet.value === "keplr") {
+  switch (wallet.value) {
+    case 'keplr':
+      if (window.keplr) {
         // @ts-ignore
-        if (window.keplr) {
-            // @ts-ignore
-            window.keplr.experimentalSuggestChain(JSON.parse(conf.value)).catch(e => {
-                error.value = e
-            })
-        }
-    } else {
-        suggestChain(JSON.parse(conf.value));
-    }
+        window.keplr
+          .experimentalSuggestChain(JSON.parse(conf.value))
+          .catch((e) => {
+            error.value = e;
+          });
+      }
+      break;
+    case 'leap':
+      if (window.leap) {
+        // @ts-ignore
+        window.leap
+          .experimentalSuggestChain(JSON.parse(conf.value))
+          .catch((e) => {
+            error.value = e;
+          });
+      }
+      break;
+    default:
+      suggestChain(JSON.parse(conf.value));
+      break;
+  }
 }
-
 </script>
 
 <template>
-    <div class="bg-base-100 p-4 rounded text-center">
-        <div class="flex text-center">
-            <select v-model="network" class="select select-bordered">
-                <option :value="NetworkType.Mainnet">Mainnet</option>
-                <option :value="NetworkType.Testnet">Testnet</option>
-            </select>
-            <select v-model="selected" class="select select-bordered mx-5" @change="onchange">
-                <option v-for="c in chains" :value="c">
-                    {{ c.chainName }}
-                </option>
-            </select>
-            <label><input type="radio" v-model="wallet" value="keplr" class="radio radio-bordered" @change="onchange" /> Keplr</label>
-            <label><input type="radio" v-model="wallet" value="metamask" class="radio radio-bordered ml-4" @change="onchange"/> Metamask</label>
-        </div>
-        <div class="text-main mt-5">
-            <textarea v-model="conf" class="textarea textarea-bordered w-full" rows="15"></textarea>
-        </div>
-        <div class="mt-4 mb-4">
+  <div class="bg-base-100 p-4 rounded text-center">
+    <div class="flex text-center">
+      <!-- <select v-model="network" class="select select-bordered">
+        <option :value="NetworkType.Mainnet">Mainnet</option>
+        <option :value="NetworkType.Testnet">Testnet</option>
+      </select> -->
 
-            <button class="btn !bg-primary !border-primary text-white mr-2" @click="suggest">Suggest {{ selected.chainName }} TO {{ wallet }}</button>
+      <!-- <select
+        v-model="selected"
+        class="select select-bordered mx-5"
+        @change="onchange"
+      >
+        <option v-for="c in chains" :value="c">
+          {{ c.chainName }}
+        </option>
+      </select> -->
+      <label
+        ><input
+          type="radio"
+          v-model="wallet"
+          value="keplr"
+          class="radio radio-bordered"
+          @change="onchange"
+        />
+        Keplr</label
+      >
+      <label
+        ><input
+          type="radio"
+          v-model="wallet"
+          value="metamask"
+          class="radio radio-bordered ml-4"
+          @change="onchange"
+        />
+        Metamask</label
+      >
 
-            <div class="mt-4">
-                If the chain is not offically support on Keplr/Metamask Snap, you can submit these parameters to enable Keplr/Metamask Snap.
-            </div>
-        </div>
+      <label
+        ><input
+          type="radio"
+          v-model="wallet"
+          value="leap"
+          class="radio radio-bordered ml-4"
+          @change="onchange"
+        />
+        Leap</label
+      >
     </div>
+    <div class="text-main mt-5">
+      <textarea
+        v-model="conf"
+        class="textarea textarea-bordered w-full"
+        rows="15"
+      ></textarea>
+    </div>
+    <div class="mt-4 mb-4">
+      <button
+        class="btn !bg-primary !border-primary text-white mr-2"
+        @click="suggest"
+      >
+        Suggest {{ selected.chainName }} TO {{ wallet }}
+      </button>
+
+      <div class="mt-4">
+        If the chain is not offically support on Keplr/Metamask Snap, you can
+        submit these parameters to enable Keplr/Metamask Snap.
+      </div>
+    </div>
+  </div>
 </template>


### PR DESCRIPTION
**Changes:**
- Import ping-widget module for allowing connecting with wallet
- Re-add the wallet helper page to allow users to suggest the allora chain to Keplr, Metamask and Leap

**Testing:**

1. Connecting with Keplr

- If the `allora-edgenet` chain is not already added to the Keplr wallet, the user will see the following error:
<img width="659" alt="Screenshot 2024-03-13 at 14 05 21" src="https://github.com/allora-network/explorer/assets/8314201/ef0e5d63-073a-4c3d-b4cc-e83967b4f994">

- When "Suggest A Chain to Keplr" is clicked, the user will be redirected to a new page that will allow adding `allora-edgenet` chain to the user's wallet
<img width="1311" alt="Screenshot 2024-03-13 at 14 05 33" src="https://github.com/allora-network/explorer/assets/8314201/fbac4512-f4c0-479f-a339-5837047f1fd0">

2. Connecting with the other supported wallets

For successfully connecting with the other supported wallets (Metamask, Leap, Ledger USB), the user should first add the `allora-edgenet` chain using the "Wallet Helper" page (route:`/wallet/suggest`).

<img width="1398" alt="Screenshot 2024-03-13 at 14 05 57" src="https://github.com/allora-network/explorer/assets/8314201/dc10937e-87dd-4e07-8fc4-51a0bdddd450">

Once the chain is added to the user's wallet, the user can repeat the connect wallet flow:

<img width="383" alt="Screenshot 2024-03-13 at 14 31 10" src="https://github.com/allora-network/explorer/assets/8314201/8eea0a38-90c5-47c6-a36a-e512b8ef4f21">

<img width="703" alt="Screenshot 2024-03-13 at 14 31 59" src="https://github.com/allora-network/explorer/assets/8314201/ea6be0f4-106c-452e-aa5c-88826f37301a">

<img width="397" alt="Screenshot 2024-03-13 at 14 32 52" src="https://github.com/allora-network/explorer/assets/8314201/6bfd84e4-132f-4c96-8c5c-f9ead564267d">
