### PR TITLE
Fix: correctly display token amount details in the explorer

### DIFF
--- a/chains-all/edgenet.json
+++ b/chains-all/edgenet.json
@@ -21,7 +21,7 @@
         {
             "base": "uallo",
             "symbol": "ALLO",
-            "exponent": "6"
+            "exponent": "18"
         }
     ],
     "logo": "/chain-logos/allora.png"

--- a/chains-all/edgenet.json
+++ b/chains-all/edgenet.json
@@ -24,5 +24,6 @@
             "exponent": "18"
         }
     ],
+    "max_total_supply": "1000000000000000000000000000",
     "logo": "/chain-logos/allora.png"
 }

--- a/chains-all/testnet.json
+++ b/chains-all/testnet.json
@@ -21,7 +21,7 @@
         {
             "base": "uallo",
             "symbol": "ALLO",
-            "exponent": "6"
+            "exponent": "18"
         }
     ],
     "logo": "/chain-logos/allora.png"

--- a/chains-all/testnet.json
+++ b/chains-all/testnet.json
@@ -24,5 +24,6 @@
             "exponent": "18"
         }
     ],
+    "max_total_supply": "1000000000000000000000000000",
     "logo": "/chain-logos/allora.png"
 }

--- a/chains/edgenet.json
+++ b/chains/edgenet.json
@@ -21,7 +21,7 @@
         {
             "base": "uallo",
             "symbol": "ALLO",
-            "exponent": "6"
+            "exponent": "18"
         }
     ],
     "logo": "/chain-logos/allora.png"

--- a/chains/edgenet.json
+++ b/chains/edgenet.json
@@ -24,5 +24,6 @@
             "exponent": "18"
         }
     ],
+    "max_total_supply": "1000000000000000000000000000",
     "logo": "/chain-logos/allora.png"
 }

--- a/chains/testnet.json
+++ b/chains/testnet.json
@@ -21,7 +21,7 @@
         {
             "base": "uallo",
             "symbol": "ALLO",
-            "exponent": "6"
+            "exponent": "18"
         }
     ],
     "logo": "/chain-logos/allora.png"

--- a/chains/testnet.json
+++ b/chains/testnet.json
@@ -24,5 +24,6 @@
             "exponent": "18"
         }
     ],
+    "max_total_supply": "1000000000000000000000000000",
     "logo": "/chain-logos/allora.png"
 }

--- a/src/components/CardStatisticsVertical.vue
+++ b/src/components/CardStatisticsVertical.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue';
-import { controlledComputed } from '@vueuse/core'
+import { controlledComputed } from '@vueuse/core';
 
 interface Props {
   title: string;
@@ -47,7 +47,7 @@ const isPositive = controlledComputed(
 
     <div class="">
       <h6 class="text-lg text-center font-semibold mt-2 mb-1">
-        {{ props.stats || '-'}}
+        {{ props.stats || '-' }}
       </h6>
       <p class="text-sm text-center">
         {{ props.title }}

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -339,7 +339,7 @@ const amount = computed({
       </div>
     </div>
 
-    <div class="grid grid-cols-1 gap-4 md:!grid-cols-3 lg:!grid-cols-6">
+    <div class="grid grid-cols-1 gap-2 md:!grid-cols-3 lg:!grid-cols-7">
       <div v-for="(item, key) in store.stats" :key="key">
         <CardStatisticsVertical v-bind="item" />
       </div>

--- a/src/modules/[chain]/indexStore.ts
+++ b/src/modules/[chain]/indexStore.ts
@@ -87,33 +87,33 @@ export const useIndexModule = defineStore('module-index', {
       return useBankStore();
     },
     twitter(): string {
-      if(!this.coinInfo?.links?.twitter_screen_name) return ""
+      if (!this.coinInfo?.links?.twitter_screen_name) return '';
       return `https://twitter.com/${this.coinInfo?.links.twitter_screen_name}`;
     },
     homepage(): string {
-      if(!this.coinInfo?.links?.homepage) return ""
+      if (!this.coinInfo?.links?.homepage) return '';
       const [page1, page2, page3] = this.coinInfo?.links?.homepage;
       return page1 || page2 || page3;
     },
     github(): string {
-      if(!this.coinInfo?.links?.repos_url) return ""
+      if (!this.coinInfo?.links?.repos_url) return '';
       const [page1, page2, page3] = this.coinInfo?.links?.repos_url?.github;
       return page1 || page2 || page3;
     },
     telegram(): string {
-      if(!this.coinInfo?.links?.homepage) return ""
+      if (!this.coinInfo?.links?.homepage) return '';
       return `https://t.me/${this.coinInfo?.links.telegram_channel_identifier}`;
     },
 
     priceChange(): string {
-      if(!this.coinInfo?.market_data?.price_change_percentage_24h) return ""
+      if (!this.coinInfo?.market_data?.price_change_percentage_24h) return '';
       const change =
         this.coinInfo?.market_data?.price_change_percentage_24h || 0;
       return numeral(change).format('+0.[00]');
     },
 
     priceColor(): string {
-      if(!this.coinInfo?.market_data?.price_change_percentage_24h) return ""
+      if (!this.coinInfo?.market_data?.price_change_percentage_24h) return '';
       const change =
         this.coinInfo?.market_data?.price_change_percentage_24h || 0;
       switch (true) {
@@ -126,7 +126,7 @@ export const useIndexModule = defineStore('module-index', {
       }
     },
     trustColor(): string {
-      if(!this.coinInfo?.tickers) return ""
+      if (!this.coinInfo?.tickers) return '';
       const change = this.coinInfo?.tickers[this.tickerIndex]?.trust_score;
       return change;
     },
@@ -137,8 +137,8 @@ export const useIndexModule = defineStore('module-index', {
     },
 
     proposals() {
-      const gov = useGovStore()
-      return gov.proposals['2']
+      const gov = useGovStore();
+      return gov.proposals['2'];
     },
 
     stats() {
@@ -160,7 +160,9 @@ export const useIndexModule = defineStore('module-index', {
           title: 'Validators',
           color: 'error',
           icon: 'mdi-human-queue',
-          stats: String(base?.latest?.block?.last_commit?.signatures.length || 0),
+          stats: String(
+            base?.latest?.block?.last_commit?.signatures.length || 0
+          ),
           change: 0,
         },
         {
@@ -168,6 +170,13 @@ export const useIndexModule = defineStore('module-index', {
           color: 'success',
           icon: 'mdi-currency-usd',
           stats: formatter.formatTokenAmount(bank.supply),
+          change: 0,
+        },
+        {
+          title: 'Max Total Supply',
+          color: 'success',
+          icon: 'mdi-arrow-up-bold-circle',
+          stats: formatter.formatTokenAmount(bank.maxTotalSupply),
           change: 0,
         },
         {
@@ -207,8 +216,8 @@ export const useIndexModule = defineStore('module-index', {
       this.tickerIndex = 0;
       // @ts-ignore
       const [firstAsset] = this.blockchain?.assets || [];
-      return firstAsset.coingecko_id
-    }
+      return firstAsset.coingecko_id;
+    },
   },
   actions: {
     async loadDashboard() {

--- a/src/stores/useBankStore.ts
+++ b/src/stores/useBankStore.ts
@@ -10,7 +10,7 @@ export const useBankStore = defineStore('bankstore', {
       supply: {} as Coin,
       balances: {} as Record<string, Coin[]>,
       totalSupply: { supply: [] as Coin[] },
-      ibcDenoms: {} as Record<string, DenomTrace>
+      ibcDenoms: {} as Record<string, DenomTrace>,
     };
   },
   getters: {
@@ -28,6 +28,10 @@ export const useBankStore = defineStore('bankstore', {
       const denom =
         this.staking.params.bond_denom ||
         this.blockchain.current?.assets[0].base;
+      this.maxTotalSupply = {
+        denom: denom,
+        amount: this.blockchain.current?.maxTotalSupply,
+      } as Coin;
       if (denom) {
         this.blockchain.rpc.getBankSupplyByDenom(denom).then((res) => {
           if (res.amount) this.supply = res.amount;

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -61,6 +61,7 @@ export interface ChainConfig {
   chainId: string;
   coinType: string;
   assets: Asset[];
+  maxTotalSupply: string;
   themeColor?: string;
   features?: string[];
   endpoints: {
@@ -151,6 +152,7 @@ export function fromLocal(lc: LocalConfig): ChainConfig {
       { denom: x.symbol.toLowerCase(), exponent: Number(x.exponent) },
     ],
   }));
+  conf.maxTotalSupply = lc.max_total_supply;
   conf.versions = {
     cosmosSdk: lc.sdk_version,
   };
@@ -174,6 +176,8 @@ export function fromLocal(lc: LocalConfig): ChainConfig {
   conf.keplrFeatures = lc.keplr_features;
   conf.keplrPriceStep = lc.keplr_price_step;
   conf.themeColor = lc.theme_color;
+
+  console.log('$$$$', conf);
   return conf;
 }
 


### PR DESCRIPTION
- Fix `uallo` exponent (use 18 instead of 6)
- Added card displaying max total supply on each network

![Screenshot 2024-03-27 at 16 13 38](https://github.com/allora-network/explorer/assets/8314201/a547b424-4d32-47af-9fc7-75643d7f9cf1)
