### PR TITLE
Temporarily remove misleading inflation metric

### DIFF
--- a/src/modules/[chain]/indexStore.ts
+++ b/src/modules/[chain]/indexStore.ts
@@ -190,13 +190,14 @@ export const useIndexModule = defineStore('module-index', {
           }),
           change: 0,
         },
-        {
-          title: 'Inflation',
-          color: 'success',
-          icon: 'mdi-chart-multiple',
-          stats: formatter.formatDecimalToPercent(mintStore.inflation),
-          change: 0,
-        },
+        // Temporarily remove the misleading inflation metric
+        // {
+        //   title: 'Inflation',
+        //   color: 'success',
+        //   icon: 'mdi-chart-multiple',
+        //   stats: formatter.formatDecimalToPercent(mintStore.inflation),
+        //   change: 0,
+        // },
         {
           title: 'Community Pool',
           color: 'primary',


### PR DESCRIPTION
Before:
<img width="1746" alt="Screenshot 2024-08-28 at 15 51 29" src="https://github.com/user-attachments/assets/dc085131-728a-4473-ba2e-b19c4a0d9ba1">


After:
<img width="1749" alt="Screenshot 2024-08-28 at 15 51 12" src="https://github.com/user-attachments/assets/cd9b0708-5235-489a-a35d-151994cb1bf6">
